### PR TITLE
Change error handling logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ add_subdirectory(tests)
 # set up versioning.
 set(BUILD_MAJOR "1")
 set(BUILD_MINOR "0")
-set(BUILD_VERSION "9")
+set(BUILD_VERSION "10")
 set(BUILD_VERSION ${BUILD_MAJOR}.${BUILD_MINOR}.${BUILD_VERSION})
 
 set(CMAKE_C_STANDARD 11)

--- a/src/cotp.h
+++ b/src/cotp.h
@@ -1,20 +1,33 @@
 #pragma once
 #include <gcrypt.h>
 
-#define INVALID_ALGO -4
-#define HOTP_NOT_VALID -3
-#define TOTP_NOT_VALID -2
-#define GCRYPT_VERSION_MISMATCH -1
-#define TOTP_VALID 1
-#define HOTP_VALID 2
-#define VALID_ALGO 3
-
 #define SHA1 GCRY_MD_SHA1
 #define SHA256 GCRY_MD_SHA256
 #define SHA512 GCRY_MD_SHA512
 
-char *get_hotp (const char *base32_encoded_secret, long counter, int digits, int sha_algo);
-char *get_totp (const char *base32_encoded_secret, int digits, int sha_algo);
-char *get_totp_at (const char *base32_encoded_secret, long time, int digits, int sha_algo);
+typedef enum _errno {
+    VALID = 0,
+    GCRYPT_VERSION_MISMATCH = 1,
+    INVALID_B32_INPUT = 2,
+    INVALID_ALGO = 3,
+    INVALID_OTP = 4
+} cotp_error_t;
+
+
+struct _errno_to_str {
+    int  code;
+    char *message;
+} errno_to_str[] = {
+        { VALID, "" },
+        { GCRYPT_VERSION_MISMATCH, "The install Gcrypt library is too old" },
+        { INVALID_B32_INPUT, "The given input is not base32 encoded"},
+        { INVALID_ALGO, "The specified algorithm is not supported" },
+        { INVALID_OTP, "The OTP is not valid" },
+};
+
+
+char *get_hotp (const char *base32_encoded_secret, long counter, int digits, int sha_algo, cotp_error_t *err_code);
+char *get_totp (const char *base32_encoded_secret, int digits, int sha_algo, cotp_error_t *err_code);
+char *get_totp_at (const char *base32_encoded_secret, long time, int digits, int sha_algo, cotp_error_t *err_code);
 int totp_verify (const char *base32_encoded_secret, int digits, const char *user_totp, int sha_algo);
 int hotp_verify (const char *base32_encoded_secret, long counter, int digits, const char *user_hotp, int sha_algo);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,8 +1,8 @@
 
 IF(BUILD_TESTING)
-    add_executable (test_cotp ../src/otp.c check_otp.c)
+    add_executable (test_cotp check_otp.c)
 
-    target_link_libraries (test_cotp -lcriterion -lbaseencode -lgcrypt)
+    target_link_libraries (test_cotp -lcotp -lcriterion -lbaseencode -lgcrypt)
 
     add_test (NAME TestCOTP COMMAND test_cotp)
 ENDIF(BUILD_TESTING)


### PR DESCRIPTION
This causes API breakage with previous versions.

Please have a look at the README for more information on how to use the new APIs.