### PR TITLE
fix compute_hmac secret_len

### DIFF
--- a/src/otp.c
+++ b/src/otp.c
@@ -89,6 +89,11 @@ compute_hmac(const char *K, long C, int algo)
         return NULL;
     }
 
+    if(secret_len > (size_t)strlen((char*)secret))
+    {
+        secret_len = (size_t)strlen((char*)secret);
+    }
+
     unsigned char C_reverse_byte_order[8];
     int j, i;
     for (j = 0, i = 7; j < 8 && i >= 0; j++, i--)


### PR DESCRIPTION
size_t secret_len = (size_t) ((strlen(K) + 1.6 - 1) / 1.6); //can't  understand why set secret_len this way?
//but i found sometimes secret_len > strlen(secret) ,then would not get the right  result.