### PR TITLE
Integ/openssl wrapper signed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ set(COTP_HEADERS
         )
 set(SOURCE_FILES
         src/otp.c
+        src/utils/whmac_gcrypt.c
         src/utils/base32.c
         )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,16 +3,34 @@ project(cotp VERSION "2.0.2" LANGUAGES "C")
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
+set(HMACWRAPPER "gcrypt" CACHE STRING "library to use during hmac computation")
 include(GNUInstallDirs)
 
 find_package(PkgConfig REQUIRED)
-find_package(Gcrypt 1.8.0 REQUIRED)
+
+if("${HMACWRAPPER}" STREQUAL "gcrypt")
+  set(HMAC_SOURCE_FILES src/utils/whmac_gcrypt.c)
+  find_package(Gcrypt 1.8.0 REQUIRED)
+  set(HMAC_INCLUDE_DIR ${GCRYPT_INCLUDE_DIR})
+  set(HMAC_LIBRARY_DIRS ${GCRYPT_LIBRARY_DIRS})
+  set(HMAC_LIBRARIES ${GCRYPT_LIBRARIES})
+  message("copt use gcrypt for hmac")
+elseif("${HMACWRAPPER}" STREQUAL "openssl")
+  find_package(OpenSSL 3.0.0 REQUIRED)
+  set(HMAC_SOURCE_FILES src/utils/whmac_openssl.c)
+  set(HMAC_INCLUDE_DIR ${OPENSSL_INCLUDE_DIR})
+  set(HMAC_LIBRARY_DIRS ${OPENSSL_LIBRARY_DIRS})
+  set(HMAC_LIBRARIES ${OPENSSL_LIBRARIES})
+  message("libcopt use openssl for hmac")
+else()
+  message("libcopt can't use ${HMACWRAPPER} for hmac")
+endif()
 
 option(BUILD_SHARED_LIBS "Build libcotp as a shared library" ON)
 
-include_directories(${GCRYPT_INCLUDE_DIR} ${BASEENCODE_INCLUDE_DIRS})
+include_directories(${HMAC_INCLUDE_DIR} ${BASEENCODE_INCLUDE_DIRS})
 
-link_directories(${GCRYPT_LIBRARY_DIRS} ${BASEENCODE_LIBRARY_DIRS})
+link_directories(${HMAC_LIBRARY_DIRS} ${BASEENCODE_LIBRARY_DIRS})
 
 enable_testing()
 add_subdirectory(tests)
@@ -24,7 +42,7 @@ set(COTP_HEADERS
         )
 set(SOURCE_FILES
         src/otp.c
-        src/utils/whmac_gcrypt.c
+        ${HMAC_SOURCE_FILES}
         src/utils/base32.c
         )
 
@@ -37,19 +55,19 @@ add_link_options(-Wl,--no-add-needed -Wl,--as-needed -Wl,-z,relro,-z,now)
 
 add_library(cotp ${SOURCE_FILES})
 
-target_link_libraries(cotp ${GCRYPT_LIBRARIES})
+target_link_libraries(cotp ${HMAC_LIBRARIES})
 target_include_directories(cotp
         PUBLIC
             ${CMAKE_CURRENT_SOURCE_DIR}/src
         PRIVATE
-            ${GCRYPT_INCLUDE_DIR}
+            ${HMAC_INCLUDE_DIR}
             ${BASEENCODE_INCLUDE_DIRS})
 target_compile_options(cotp PRIVATE
         -Wall -Wextra -O3 -Wformat=2 -Wmissing-format-attribute -fstack-protector-strong -Wundef -Wmissing-format-attribute
         -fdiagnostics-color=always -Wstrict-prototypes -Wunreachable-code -Wchar-subscripts -Wwrite-strings -Wpointer-arith -Wbad-function-cast
         -Wcast-align -Werror=format-security -Werror=implicit-function-declaration -Wno-sign-compare -Wno-format-nonliteral -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3)
 target_link_directories(cotp PRIVATE
-        ${GCRYPT_LIBRARY_DIRS} ${BASEENCODE_LIBRARY_DIRS})
+        ${HMACLIBRARY_DIRS} ${BASEENCODE_LIBRARY_DIRS})
 
 set_target_properties(cotp PROPERTIES VERSION ${CMAKE_PROJECT_VERSION} SOVERSION ${CMAKE_PROJECT_VERSION_MAJOR})
 

--- a/src/cotp.h
+++ b/src/cotp.h
@@ -1,10 +1,9 @@
 #pragma once
-#include <gcrypt.h>
 #include <stdint.h>
 
-#define SHA1 GCRY_MD_SHA1
-#define SHA256 GCRY_MD_SHA256
-#define SHA512 GCRY_MD_SHA512
+#define SHA1 0
+#define SHA256 1
+#define SHA512 2
 
 #define MIN_DIGTS 4
 #define MAX_DIGITS 10
@@ -12,7 +11,7 @@
 typedef enum cotp_error {
     NO_ERROR = 0,
     VALID,
-    GCRYPT_VERSION_MISMATCH,
+    WCRYPT_VERSION_MISMATCH,
     INVALID_B32_INPUT,
     INVALID_ALGO,
     INVALID_DIGITS,

--- a/src/otp.c
+++ b/src/otp.c
@@ -205,7 +205,9 @@ normalize_secret (const char *K)
 static char *
 get_steam_code (const unsigned char *hmac)
 {
-    int offset = (hmac[whmac_getlen(SHA1)-1] & 0x0f);
+    whmac_handle_t *hd = whmac_gethandle(SHA1);
+    int offset = (hmac[whmac_getlen(hd)-1] & 0x0f);
+    whmac_freehandle(hd);
 
     // Starting from the offset, take the successive 4 bytes while stripping the topmost bit to prevent it being handled as a signed integer
     int bin_code = ((hmac[offset] & 0x7f) << 24) | ((hmac[offset + 1] & 0xff) << 16) | ((hmac[offset + 2] & 0xff) << 8) | ((hmac[offset + 3] & 0xff));
@@ -231,7 +233,9 @@ truncate (const unsigned char *hmac,
           int            algo)
 {
     // take the lower four bits of the last byte
-    int offset = hmac[whmac_getlen(algo) - 1] & 0x0f;
+    whmac_handle_t *hd = whmac_gethandle(algo);
+    int offset = hmac[whmac_getlen(hd) - 1] & 0x0f;
+    whmac_freehandle(hd);
 
     // Starting from the offset, take the successive 4 bytes while stripping the topmost bit to prevent it being handled as a signed integer
     int bin_code = ((hmac[offset] & 0x7f) << 24) | ((hmac[offset + 1] & 0xff) << 16) | ((hmac[offset + 2] & 0xff) << 8) | ((hmac[offset + 3] & 0xff));
@@ -283,7 +287,7 @@ compute_hmac (const char *K,
     }
     whmac_update (hd, C_reverse_byte_order, sizeof (C_reverse_byte_order));
 
-    size_t dlen = whmac_getlen(algo);
+    size_t dlen = whmac_getlen(hd);
     unsigned char *hmac = malloc (dlen);
     if (hmac == NULL) {
         fprintf (stderr, "Error allocating memory");

--- a/src/utils/whmac_gcrypt.c
+++ b/src/utils/whmac_gcrypt.c
@@ -1,0 +1,103 @@
+#include <gcrypt.h>
+#include "whmac.h"
+#include "cotp.h"
+
+typedef struct whmac_handle_s whmac_handle_t;
+
+struct whmac_handle_s
+{
+    gcry_md_hd_t hd;
+    int algo;
+};
+
+int gcrypt_algo[]=
+{
+    GCRY_MD_SHA1,
+    GCRY_MD_SHA256,
+    GCRY_MD_SHA512,
+};
+
+int
+whmac_check (void)
+{
+    if (!gcry_control (GCRYCTL_INITIALIZATION_FINISHED_P)) {
+        if (!gcry_check_version ("1.8.0")) {
+            fprintf (stderr, "libgcrypt v1.8.0 and above is required\n");
+            return -1;
+        }
+        gcry_control (GCRYCTL_DISABLE_SECMEM, 0);
+        gcry_control (GCRYCTL_INITIALIZATION_FINISHED, 0);
+    }
+    return 0;
+}
+
+size_t
+whmac_getlen (whmac_handle_t *hd)
+{
+    return gcry_md_get_algo_dlen(hd->algo);
+}
+
+whmac_handle_t *
+whmac_gethandle (int algo)
+{
+    whmac_handle_t *whmac_handle = NULL;
+    gcry_md_hd_t hd;
+    if (algo >= sizeof(gcrypt_algo)/sizeof(int))
+        return NULL;
+    gpg_error_t gpg_err = gcry_md_open (&hd, gcrypt_algo[algo], GCRY_MD_FLAG_HMAC);
+    if (gpg_err == 0) {
+        whmac_handle = calloc(1, sizeof(*whmac_handle));
+        memcpy(&whmac_handle->hd, &hd, sizeof(hd));
+        whmac_handle->algo = gcrypt_algo[algo];
+    }
+    return whmac_handle;
+}
+
+void
+whmac_freehandle (whmac_handle_t *hd)
+{
+    gcry_md_close (hd->hd);
+    free(hd);
+}
+
+int
+whmac_setkey (whmac_handle_t *hd,
+                unsigned char * buffer,
+                size_t buflen)
+{
+    if (gcry_md_setkey (hd->hd, buffer, buflen)) {
+        return -INVALID_ALGO;
+    }
+    return NO_ERROR;
+}
+
+void
+whmac_update (whmac_handle_t *hd,
+                unsigned char * buffer,
+                size_t buflen)
+{
+    gcry_md_write (hd->hd, buffer, buflen);
+}
+
+ssize_t
+whmac_finalize(whmac_handle_t *hd,
+                unsigned char * buffer,
+                size_t buflen)
+{
+    ssize_t dlen = gcry_md_get_algo_dlen(hd->algo);
+    if (buffer == NULL)
+        return dlen;
+
+    if (dlen > buflen) {
+        return -MEMORY_ALLOCATION_ERROR;
+    }
+
+    gcry_md_final (hd->hd);
+
+    unsigned char *hmac_tmp = gcry_md_read (hd->hd, hd->algo);
+    if (hmac_tmp == NULL) {
+        return -MEMORY_ALLOCATION_ERROR;
+    }
+    memcpy (buffer, hmac_tmp, dlen);
+    return dlen;
+}

--- a/src/utils/whmac_openssl.c
+++ b/src/utils/whmac_openssl.c
@@ -1,0 +1,108 @@
+#include <openssl/conf.h>
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
+#include <openssl/err.h>
+#include "whmac.h"
+#include "cotp.h"
+
+typedef struct whmac_handle_s whmac_handle_t;
+
+struct whmac_handle_s
+{
+    EVP_MAC *mac;
+    OSSL_PARAM mac_params[4];
+    EVP_MAC_CTX *ctx;
+    int algo;
+    size_t dlen;
+};
+
+static char *openssl_algo[] = 
+{
+    (char *)"SHA1",
+    (char *)"SHA256",
+    (char *)"SHA512",
+};
+
+int
+whmac_check (void)
+{
+    return 0;
+}
+
+size_t
+whmac_getlen (whmac_handle_t *hd)
+{
+    return hd->dlen;
+}
+
+whmac_handle_t *
+whmac_gethandle (int algo)
+{
+    whmac_handle_t *whmac_handle = NULL;
+    if (algo >= sizeof(openssl_algo)/sizeof(char *))
+    return NULL;
+
+    EVP_MAC *mac = EVP_MAC_fetch(NULL, "HMAC", NULL);
+    if (mac != NULL) {
+    whmac_handle = calloc(1, sizeof(*whmac_handle));
+    whmac_handle->mac = mac;
+    whmac_handle->algo = algo;
+
+    size_t params_n = 0;
+
+    whmac_handle->mac_params[params_n++] =
+            OSSL_PARAM_construct_utf8_string("digest", openssl_algo[algo], 0);
+    whmac_handle->mac_params[params_n] = OSSL_PARAM_construct_end();
+    }
+    return whmac_handle;
+}
+
+void
+whmac_freehandle (whmac_handle_t *hd)
+{
+    EVP_MAC_free (hd->mac);
+    free(hd);
+}
+
+int
+whmac_setkey (whmac_handle_t *hd,
+              unsigned char * buffer,
+              size_t buflen)
+{
+    hd->ctx = EVP_MAC_CTX_new(hd->mac);
+    if (hd->ctx &&
+        ! EVP_MAC_init(hd->ctx, buffer, buflen, hd->mac_params)) {
+        ERR_print_errors_fp(stderr);
+        return -INVALID_ALGO;
+    }
+    hd->dlen = EVP_MAC_CTX_get_mac_size(hd->ctx);
+    return NO_ERROR;
+}
+
+void
+whmac_update (whmac_handle_t *hd,
+              unsigned char * buffer,
+              size_t buflen)
+{
+    EVP_MAC_update (hd->ctx, buffer, buflen);
+}
+
+ssize_t
+whmac_finalize(whmac_handle_t *hd,
+               unsigned char * buffer,
+               size_t buflen)
+{
+    size_t dlen = EVP_MAC_CTX_get_mac_size(hd->ctx);
+    if (buffer == NULL)
+        return dlen;
+
+    if (dlen > buflen) {
+        return -MEMORY_ALLOCATION_ERROR;
+    }
+
+    EVP_MAC_final(hd->ctx, buffer, &dlen, buflen);
+    EVP_MAC_CTX_free(hd->ctx);
+    hd->ctx = NULL;
+
+    return dlen;
+}

--- a/src/whmac.h
+++ b/src/whmac.h
@@ -1,0 +1,24 @@
+#pragma once
+
+typedef struct whmac_handle_s whmac_handle_t;
+
+int             whmac_check      (void);
+
+int             whmac_getlen     (int algotype);
+
+whmac_handle_t* whmac_gethandle  (int algo);
+
+void            whmac_freehandle (whmac_handle_t *hd);
+
+int             whmac_setkey     (whmac_handle_t *hd,
+                                  unsigned char  *buffer,
+                                  size_t         buflen);
+
+void            whmac_update     (whmac_handle_t *hd,
+                                  unsigned char  *buffer,
+                                  size_t         buflen);
+
+ssize_t         whmac_finalize   (whmac_handle_t *hd,
+                                  unsigned char  *buffer,
+                                  size_t         buflen);
+

--- a/src/whmac.h
+++ b/src/whmac.h
@@ -4,9 +4,9 @@ typedef struct whmac_handle_s whmac_handle_t;
 
 int             whmac_check      (void);
 
-int             whmac_getlen     (int algotype);
-
 whmac_handle_t* whmac_gethandle  (int algo);
+
+size_t          whmac_getlen     (whmac_handle_t* hd);
 
 void            whmac_freehandle (whmac_handle_t *hd);
 

--- a/tests/test_otp.c
+++ b/tests/test_otp.c
@@ -212,12 +212,12 @@ Test(totp_generic, test_fail_invalid_b32_input) {
     cr_assert_null (totp);
 }
 
-
+#define MD5 3
 Test(totp_generic, test_fail_invalid_algo) {
     const char *K = "base32secret";
 
     cotp_error_t err;
-    char *totp = get_totp (K, 6, 30, GCRY_MD_MD5, &err);
+    char *totp = get_totp (K, 6, 30, MD5, &err);
 
     cr_expect_eq (err, INVALID_ALGO, "Expected %d to be equal to %d\n", err, INVALID_ALGO);
     cr_assert_null (totp);


### PR DESCRIPTION
Hello,
Here my support for openssl into libcotp. I need it to embed only one hmac library on my system.
Best regards,
Marc.

This pullrequest is signed and contains:

  - a wrapper around all hmac function
  - a wrapper for libgcrypt
  - a wrapper for libcrypto (openssl 3.0.0)
 
Modifications:
  - the hmac context is a dynamic pointer.
  - this same pointer creation move into a function call up and free at the same level.
  - the dlen getter function needs the context pointer.
  - the MD5 macro is defined into the test file.

API modifications
 -  none

Testing:
 -  all tests from test_cotp pass for gcrypt and openssl.

