### PR TITLE
fix: HMAC的增加了mbedtls的适配接口。

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,18 @@ elseif("${HMAC_WRAPPER}" STREQUAL "openssl")
     set(HMAC_LIBRARY_DIRS ${OPENSSL_LIBRARY_DIRS})
     set(HMAC_LIBRARIES ${OPENSSL_LIBRARIES})
     message("libcotp will use openssl for hmac")
+elseif("${HMAC_WRAPPER}" STREQUAL "mbedtls")
+    # find_package(mbedtls)
+    set(HMAC_SOURCE_FILES
+            src/utils/whmac_mbedtls.c
+    )
+    set(HMAC_INCLUDE_DIR "/usr/include/mbedtls")
+    set(HMAC_LIBRARY_DIRS )
+    set(HMAC_LIBRARIES   "/lib/x86_64-linux-gnu/libmbedcrypto.so")
+    set(HMAC_LIBRARIES_1 "/lib/x86_64-linux-gnu/libmbedx509.so")
+    set(HMAC_LIBRARIES_2 "/lib/x86_64-linux-gnu/libmbedtls.so")
+    # set(HMAC_LIBRARIES "libmbedx509.so libmbedtls.so libmbedcrypto.so")
+    message("libcotp will use mbedtls for hmac")
 else()
     message("libcotp can't use ${HMAC_WRAPPER} for hmac")
 endif()
@@ -62,6 +74,8 @@ endif()
 add_library(cotp ${SOURCE_FILES})
 
 target_link_libraries(cotp ${HMAC_LIBRARIES})
+target_link_libraries(cotp ${HMAC_LIBRARIES_1})
+target_link_libraries(cotp ${HMAC_LIBRARIES_2})
 target_include_directories(cotp
         PUBLIC
             ${CMAKE_CURRENT_SOURCE_DIR}/src

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ $ cd libcotp
 $ mkdir build && cd $_
 $ cmake -DCMAKE_INSTALL_PREFIX=/usr ..
 $ make
-# make install
+# sudo make install
 ```
 
 Available options you can pass to `cmake`:
 * `-DBUILD_TESTS=ON`: if you want to compile also the tests (default **OFF**, requires criterion)
 * `-DBUILD_SHARED_LIBS=ON`: if you want to build libcotp as a shared library (default **ON**)
-* `-DHMAC_WRAPPER="<gcrypt|openssl>"`: you can choose between GCrypt and OpenSSL (default **Gcrypt**)
+* `-DHMAC_WRAPPER="<gcrypt|openssl|mbedtls>"`: you can choose between GCrypt and OpenSSL (default **Gcrypt**)
 
 ## How To Use It
 ```

--- a/src/otp.c
+++ b/src/otp.c
@@ -155,7 +155,7 @@ get_steam_totp_at (const char   *secret,
         return NULL;
     }
 
-    whmac_handle_t *hd = whmac_gethandle (SHA256);
+    whmac_handle_t *hd = whmac_gethandle (SHA1);
     if (hd == NULL) {
         fprintf (stderr, "Error while opening the cipher handle.\n");
         return NULL;

--- a/src/otp.c
+++ b/src/otp.c
@@ -155,7 +155,7 @@ get_steam_totp_at (const char   *secret,
         return NULL;
     }
 
-    whmac_handle_t *hd = whmac_gethandle (SHA1);
+    whmac_handle_t *hd = whmac_gethandle (SHA256);
     if (hd == NULL) {
         fprintf (stderr, "Error while opening the cipher handle.\n");
         return NULL;

--- a/src/utils/whmac_mbedtls.c
+++ b/src/utils/whmac_mbedtls.c
@@ -1,0 +1,93 @@
+#include "mbedtls/md.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include "../whmac.h"
+#include "../cotp.h"
+
+typedef struct whmac_handle_s whmac_handle_t;
+
+struct whmac_handle_s
+{
+    mbedtls_md_context_t sha_ctx;
+    const mbedtls_md_info_t    *md_info;
+    int algo;
+    size_t dlen;
+};
+
+int whmac_check(void)
+{
+    return 0;
+}
+
+size_t
+whmac_getlen(whmac_handle_t *hd)
+{
+    printf("HMAC Algo is %s\n", mbedtls_md_get_name(hd->md_info));
+    return mbedtls_md_get_size(hd->md_info);
+}
+
+whmac_handle_t *
+whmac_gethandle(int algo)
+{
+    int ret = 0;
+    const mbedtls_md_type_t openssl_algo[] = {
+        MBEDTLS_MD_SHA1,
+        MBEDTLS_MD_SHA256,
+        MBEDTLS_MD_SHA512,
+    };
+
+    whmac_handle_t *whmac_handle = calloc(1, sizeof(*whmac_handle));
+    if (whmac_handle == NULL)
+    {
+        return NULL;
+    }
+
+    if (algo > 2)
+    {
+        free(whmac_handle);
+        return NULL;
+    }
+    
+    mbedtls_md_init(&(whmac_handle->sha_ctx));
+    whmac_handle->md_info = mbedtls_md_info_from_type(openssl_algo[algo]);
+    ret = mbedtls_md_setup(&(whmac_handle->sha_ctx), whmac_handle->md_info, 1);
+    if (ret != 0) {
+        printf("mbedtls_md_setup() returned -0x%04x\n", -ret);
+        mbedtls_md_free(&(whmac_handle->sha_ctx));
+        free(whmac_handle);
+        return NULL;
+    }
+
+    return whmac_handle;
+}
+
+void whmac_freehandle(whmac_handle_t *hd)
+{
+    mbedtls_md_free(&(hd->sha_ctx));
+    free(hd);
+}
+
+int whmac_setkey(whmac_handle_t *hd,
+                 unsigned char *buffer,
+                 size_t buflen)
+{
+    mbedtls_md_hmac_starts(&(hd->sha_ctx), buffer, buflen);
+    return NO_ERROR;
+}
+
+void whmac_update(whmac_handle_t *hd,
+                  unsigned char *buffer,
+                  size_t buflen)
+{   
+    mbedtls_md_hmac_update(&(hd->sha_ctx), buffer, buflen);
+}
+
+ssize_t
+whmac_finalize(whmac_handle_t *hd,
+               unsigned char *buffer,
+               size_t buflen)
+{
+    mbedtls_md_hmac_finish(&(hd->sha_ctx), buffer);
+
+    return buflen;
+}


### PR DESCRIPTION
1、HMAC的增加了mbedtls的适配接口。     
2、cmake添加mbedtls的方式还有瑕疵，但我不会修改，希望作者帮忙。
3、在嵌入式环境，mbedtls是更受欢迎的，