### PR TITLE
libcotp: fix linker hardening flags for macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,9 @@ target_compile_options(cotp PRIVATE
         -fvisibility=hidden)
 
 if(NOT APPLE)
-    target_link_options(cotp PRIVATE -Wl,-z,relro,-z,now -Wl,-z,noexecstack)
+    target_link_options(cotp PRIVATE
+            "LINKER:-z,relro,-z,now"
+            "LINKER:-z,noexecstack")
 endif()
 
 set_target_properties(cotp PROPERTIES VERSION ${CMAKE_PROJECT_VERSION} SOVERSION ${CMAKE_PROJECT_VERSION_MAJOR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,14 +88,8 @@ target_compile_options(cotp PRIVATE
         -Wcast-align -Werror=format-security -Werror=implicit-function-declaration -Wno-sign-compare -Wno-format-nonliteral -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3
         -fvisibility=hidden)
 
-if(APPLE)
-    target_link_options(cotp PRIVATE
-            "LINKER:-dead_strip"
-            "LINKER:-undefined,error")
-elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    target_link_options(cotp PRIVATE
-            "LINKER:-z,relro,-z,now"
-            "LINKER:-z,noexecstack")
+if(NOT APPLE)
+    target_link_options(cotp PRIVATE -Wl,-z,relro,-z,now -Wl,-z,noexecstack)
 endif()
 
 set_target_properties(cotp PROPERTIES VERSION ${CMAKE_PROJECT_VERSION} SOVERSION ${CMAKE_PROJECT_VERSION_MAJOR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,15 @@ target_compile_options(cotp PRIVATE
         -Wcast-align -Werror=format-security -Werror=implicit-function-declaration -Wno-sign-compare -Wno-format-nonliteral -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3
         -fvisibility=hidden)
 
-target_link_options(cotp PRIVATE -Wl,-z,relro,-z,now -Wl,-z,noexecstack)
+if(APPLE)
+    target_link_options(cotp PRIVATE
+            "LINKER:-dead_strip"
+            "LINKER:-undefined,error")
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    target_link_options(cotp PRIVATE
+            "LINKER:-z,relro,-z,now"
+            "LINKER:-z,noexecstack")
+endif()
 
 set_target_properties(cotp PROPERTIES VERSION ${CMAKE_PROJECT_VERSION} SOVERSION ${CMAKE_PROJECT_VERSION_MAJOR})
 


### PR DESCRIPTION
Guard the ELF/Linux-specific -z linker options behind `if(NOT APPLE)` so macOS builds do not pass unsupported linker flags.